### PR TITLE
Update the Evaluator endpoint back to the original URL

### DIFF
--- a/eval-bot/src/main/resources/sbot-defaults.cfg
+++ b/eval-bot/src/main/resources/sbot-defaults.cfg
@@ -2,4 +2,4 @@
 requiredMessagePrefix = ""
 
 http.entityTimeout    = 30 seconds
-evaluator.uri         = "https://scala-evaluator-sandbox.herokuapp.com/eval"
+evaluator.uri         = "https://scala-evaluator.herokuapp.com/eval"


### PR DESCRIPTION
Now that we're building the evaluator to the original URL, we can point it back.

@andyscott @raulraja can one of you give this the thumbs up please?